### PR TITLE
fix: correct timezone input format for tracked time

### DIFF
--- a/src/pages/History.tsx
+++ b/src/pages/History.tsx
@@ -23,7 +23,7 @@ export type TimeLog = {
 export default function History() {
   const navigate = useNavigate();
   const [logs, setLogs] = useState<TimeLog[]>([]);
-  const [selectedFilter, setSelectedFilter] = useState<string>('');  // New
+  const [selectedFilter, setSelectedFilter] = useState<string>('');
 
   useEffect(() => {
     fetchLogs();
@@ -59,6 +59,16 @@ export default function History() {
     }
   };
 
+  /**
+   * Format date for Romanian display.
+   * Ensures no timezone shifts by parsing components manually.
+   * Stored date in DB is always ISO ("YYYY-MM-DD").
+   */
+  const formatDate = (dateStr: string) => {
+    const [year, month, day] = dateStr.split('-').map(Number);
+    return new Date(year, month - 1, day).toLocaleDateString('ro-RO');
+  };
+
   // Apply filtering
   const displayedLogs = selectedFilter ? filterLogs(logs, selectedFilter) : logs;
 
@@ -74,7 +84,7 @@ export default function History() {
         </button>
       </div>
 
-      {/* New Dropdown */}
+      {/* Filter Dropdown */}
       <div className="mb-4">
         <label className="mr-2 font-medium">Filter:</label>
         <select
@@ -104,7 +114,9 @@ export default function History() {
           >
             <div>
               <div className="font-bold">{log.occupations?.name || 'Unknown'}</div>
-              <div className="text-sm text-gray-700">Date: {log.date}</div>
+              <div className="text-sm text-gray-700">
+                Date: {formatDate(log.date)}
+              </div>
               <div className="text-sm text-gray-700">
                 {log.hours}h {log.minutes}m
               </div>

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -5,12 +5,10 @@ import Header from '../components/TimeTracker/Header';
 import TimeEntryForm from '../components/TimeTracker/TimeEntryForm';
 import DailySummary from '../components/TimeTracker/DailySummary';
 
-
 type Category = {
   id: string;
   name: string;
 };
-
 
 type Occupation = {
   id: string;
@@ -50,8 +48,13 @@ export default function Home() {
     if (data) setOccupations(data);
   };
 
+  const getTodayISODate = () => {
+    const now = new Date();
+    return `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}-${String(now.getDate()).padStart(2, '0')}`;
+  };
+
   const fetchTodayLogs = async () => {
-    const today = new Date().toISOString().split('T')[0];
+    const today = getTodayISODate();
     const { data } = await supabase
       .from('time_logs')
       .select('*')
@@ -59,11 +62,27 @@ export default function Home() {
     if (data) setTodayLogs(data);
   };
 
-  const handleAddTimeLog = async ({ categoryId, occupationId, hours, minutes }: { categoryId: string; occupationId: string; hours: number; minutes: number }) => {
-    const today = new Date().toISOString().split('T')[0];
+  const handleAddTimeLog = async ({
+    categoryId,
+    occupationId,
+    hours,
+    minutes
+  }: {
+    categoryId: string;
+    occupationId: string;
+    hours: number;
+    minutes: number;
+  }) => {
+    const today = getTodayISODate();
     const { error } = await supabase
       .from('time_logs')
-      .insert([{ category_id: categoryId, occupation_id: occupationId, date: today, hours, minutes }]);
+      .insert([{
+        category_id: categoryId,
+        occupation_id: occupationId,
+        date: today,
+        hours,
+        minutes
+      }]);
 
     if (error) {
       console.error(error);
@@ -77,11 +96,11 @@ export default function Home() {
 
   return (
     <div className="p-4">
-      <Header 
-      onEditClick = {() => navigate('/edit')}
-      onSignOut = {() => supabase.auth.signOut()}
-      onHistoryClick = {() => navigate('/history')}
-      onDetailedViewClick = {() => navigate('/detailed-view')}
+      <Header
+        onEditClick={() => navigate('/edit')}
+        onSignOut={() => supabase.auth.signOut()}
+        onHistoryClick={() => navigate('/history')}
+        onDetailedViewClick={() => navigate('/detailed-view')}
       />
 
       <DailySummary totalMinutes={totalMinutes} />


### PR DESCRIPTION
Fixed an issue where time logs added after midnight in Romania were saved with the previous day’s date in the database. This happened because new Date().toISOString() always used UTC time, causing a timezone shift.

Fix ensures the app now saves the current local date (Romania time) in ISO format (YYYY-MM-DD), guaranteeing accurate day tracking and correct filtering for "Today" and "Yesterday" views.